### PR TITLE
test: add mock-based unit/integration tests and apply Effective Go improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,173 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+evmc (Ethereum Virtual Machine Client) is a Go library that wraps go-ethereum's `rpc` package to provide a user-friendly EVM-compatible blockchain RPC client. It supports standard Ethereum JSON-RPC namespaces plus debug/trace for data analysis and standard token interfaces.
+
+**Status:** Work In Progress (WIP)
+
+## Commands
+
+```bash
+# 전체 테스트 실행 (live RPC 엔드포인트 필요)
+go test ./...
+
+# 네트워크 불필요한 유닛 테스트만 실행
+go test ./evmctypes/... ./evmcutils/... ./evmcsoltypes/...
+
+# 단일 테스트 실행
+go test -v -run Test_ethNamespace_BlockNumber ./...
+
+# 빌드 확인
+go build ./...
+
+# 린트 (golangci-lint 설치된 경우)
+golangci-lint run
+```
+
+## Architecture
+
+### Core Design
+
+The `Evmc` struct (`evmc.go`) is the single entry point. It holds the underlying `rpc.Client` and exposes namespaces via getter methods:
+
+```
+client.Eth()      -> *ethNamespace      (eth_* methods)
+client.Web3()     -> *web3Namespace     (web3_* methods)
+client.Debug()    -> *debugNamespace    (debug_* trace methods)
+client.Kaia()     -> *kaiaNamespace     (kaia_* methods)
+client.Contract() -> *contract          (raw contract calls)
+client.ERC20()    -> *erc20Contract     (ERC-20 token methods)
+client.ERC721()   -> *erc721Contract    (ERC-721 token methods)
+client.ERC1155()  -> *erc1155Contract   (ERC-1155 token methods)
+```
+
+### Constructors
+
+```go
+evmc.New(httpURL, opts...)                    // HTTP/HTTPS
+evmc.NewWithContext(ctx, httpURL, opts...)    // HTTP/HTTPS with context
+evmc.NewWebsocket(ctx, wsURL, opts...)        // WS/WSS
+```
+
+Options (`With*` functions): `WithConnPool`, `WithReqTimeout`, `WithMaxBatchItems`, `WithMaxBatchSize`, `WithBatchCallWorkers`, `WithWsReadBufferSize`, `WithWsWriteBufferSize`, `WithWsMessageSizeLimit`
+
+### Internal Interfaces (evmc.go)
+
+Namespaces depend on these interfaces, all implemented by `*Evmc`:
+- `caller` - single (`call`) and batch (`batchCall`, `BatchCallWithContext`) RPC calls
+- `subscriber` - WebSocket event subscriptions
+- `clientInfo` - chain ID and node version
+- `transactionSender` - raw transaction sending
+
+`BatchCallWithContext` splits elements into chunks of `maxBatchItems` and fans them out across `workers` goroutines. Default: 100 items/batch, 3 workers.
+
+### Key Files
+
+| File | Role |
+|------|------|
+| `evmc.go` | `Evmc` struct, constructors, `BatchCallWithContext`, internal interfaces |
+| `procedure.go` | All RPC method name constants (`Procedure` type) |
+| `options.go` | Client configuration (connection pool, timeouts, batch limits) |
+| `eth_namespace.go` | All `eth_*` RPC method implementations |
+| `debug_namespace.go` | All `debug_*` trace RPC implementations |
+| `kaia_namespace.go` | All `kaia_*` RPC method implementations |
+| `sending_transaction.go` | Transaction building and signing helpers |
+| `wallet.go` | Key management, address derivation |
+| `erc20.go` | Auto-generated ABI bindings - DO NOT EDIT |
+| `evmctypes/evmctypes.go` | Core EVM types (Block, Tx, Receipt, Log, etc.) |
+| `evmctypes/*_unmarshaling.go` | Custom JSON unmarshaling for each type |
+
+## Adding a New RPC Method
+
+Follow this exact sequence:
+
+1. **`procedure.go`** - Add a `Procedure` constant for the RPC method name
+   ```go
+   EthGetProof Procedure = "eth_getProof"
+   ```
+
+2. **`eth_namespace.go`** (or relevant namespace file) - Implement the method
+   ```go
+   func (e *ethNamespace) GetProof(address string, keys []string, block interface{}) (*evmctypes.Proof, error) {
+       result := new(evmctypes.Proof)
+       if err := e.c.call(context.Background(), result, EthGetProof, address, keys, block); err != nil {
+           return nil, err
+       }
+       return result, nil
+   }
+   ```
+
+3. **`evmctypes/evmctypes.go`** - Add the return type struct if needed
+
+4. **`evmctypes/*_unmarshaling.go`** - Add custom JSON unmarshaling if the RPC response uses hex-encoded fields
+
+5. **`*_namespace_test.go`** - Add an integration test (see Testing section below)
+
+6. **`docs/ethereum-jsonrpc-list.md`** - Mark the method as implemented
+
+## Adding a New Namespace
+
+1. Create `<name>_namespace.go` with a struct that embeds the required interfaces
+2. Add the namespace field to `Evmc` struct in `evmc.go`
+3. Initialize it in `newClient()` in `evmc.go`
+4. Add a getter method on `Evmc`
+5. Add Procedure constants to `procedure.go`
+
+## Testing
+
+### Important: Tests Require Live RPC Nodes
+
+All tests are **integration tests that make real network calls**. There are no mocks.
+
+- Tests using hardcoded public endpoints (BSC, etc.) may pass in CI
+- Tests using private/local endpoints (e.g., `http://61.111.3.69:18014`) will fail in most environments
+- Tests with empty URL string (`testEvmc("")`) will always panic - these are placeholders
+
+### Test Pattern
+
+Use table-driven tests with testify:
+
+```go
+func Test_ethNamespace_MethodName(t *testing.T) {
+    t.Parallel()
+    tests := []struct {
+        name string
+        url  string
+        // inputs and expected values
+    }{
+        {name: "mainnet", url: "https://..."},
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            client := testEvmc(tt.url)
+            // call and assert
+        })
+    }
+}
+```
+
+## Code Conventions
+
+- Receiver name: single letter matching struct name (`e` for ethNamespace, `d` for debugNamespace)
+- Error wrapping: `fmt.Errorf("methodName: %w", err)`
+- Use `context.Background()` for non-context-aware callers; pass context through for public APIs
+- RPC responses use hex strings for numbers - define custom `UnmarshalJSON` in a separate `*_unmarshaling.go` file. See `evmctypes/block_unmarshaling.go` for the pattern.
+- Block parameters accept `"latest"`, `"earliest"`, `"pending"`, or a hex number string. Use `evmcutils` helpers for conversion.
+
+## Known Limitations and WIP Items
+
+- WebSocket RPC: partially implemented, no reconnect/backoff
+- ERC-721 and ERC-1155 contract methods: not fully implemented
+- Trace namespace (`trace_block`, `arbtrace_block`): stub only in `trace_namespace.go`
+- Ots namespace (Otterscan): not implemented
+- `erc20.go` is auto-generated by abigen - regenerate if ABI changes, never edit manually
+
+## Do Not
+
+- Edit `erc20.go` directly (auto-generated)
+- Add observability/OpenTelemetry instrumentation (not in scope)
+- Add global variables or package-level state
+- Skip the Procedure constant step when adding RPC methods

--- a/contract_mock_test.go
+++ b/contract_mock_test.go
@@ -1,0 +1,89 @@
+package evmc
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/bbaktaeho/evmc/evmctypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_contract_mock_Query(t *testing.T) {
+	mock := newMockRPCServer(t)
+	mock.on("eth_call", func(params json.RawMessage) interface{} {
+		return "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
+	})
+
+	client := testEvmc(mock.url())
+	resp, err := client.Contract().Query(context.Background(), &evmctypes.QueryParams{
+		To:       "0xcontract",
+		Data:     "0x18160ddd",
+		NumOrTag: evmctypes.Latest,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "0xcontract", resp.To)
+	assert.Equal(t, "0x18160ddd", resp.Data)
+	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000", resp.Result)
+}
+
+func Test_contract_mock_BatchQueries(t *testing.T) {
+	mock := newMockRPCServer(t)
+	callIndex := 0
+	results := []string{
+		"0x0000000000000000000000000000000000000000000000000de0b6b3a7640000",
+		"0x0000000000000000000000000000000000000000000000000000000000000001",
+		"0x0000000000000000000000000000000000000000000000000000000000000000",
+	}
+	mock.on("eth_call", func(params json.RawMessage) interface{} {
+		result := results[callIndex%len(results)]
+		callIndex++
+		return result
+	})
+
+	client := testEvmc(mock.url())
+	queries := []*evmctypes.QueryParams{
+		{To: "0xcontract1", Data: "0x18160ddd", NumOrTag: evmctypes.Latest},
+		{To: "0xcontract2", Data: "0x70a08231", NumOrTag: evmctypes.Latest},
+		{To: "0xcontract3", Data: "0x06fdde03", NumOrTag: evmctypes.Latest},
+	}
+
+	resps, err := client.Contract().BatchQueries(queries)
+	require.NoError(t, err)
+	require.Len(t, resps, 3)
+	assert.Equal(t, "0xcontract1", resps[0].To)
+	assert.Equal(t, "0xcontract2", resps[1].To)
+	assert.Equal(t, "0xcontract3", resps[2].To)
+	assert.Equal(t, results[0], resps[0].Result)
+}
+
+func Test_contract_mock_BatchQueries_emptyList(t *testing.T) {
+	mock := newMockRPCServer(t)
+	client := testEvmc(mock.url())
+
+	resps, err := client.Contract().BatchQueries([]*evmctypes.QueryParams{})
+	require.NoError(t, err)
+	assert.Empty(t, resps)
+}
+
+func Test_contract_mock_Query_withBlockNumber(t *testing.T) {
+	mock := newMockRPCServer(t)
+	mock.on("eth_call", func(params json.RawMessage) interface{} {
+		var args []json.RawMessage
+		json.Unmarshal(params, &args)
+		// 두 번째 파라미터가 블록 태그/번호여야 함
+		assert.Len(t, args, 2)
+		return "0x0000000000000000000000000000000000000000000000000000000000000001"
+	})
+
+	client := testEvmc(mock.url())
+	resp, err := client.Contract().Query(context.Background(), &evmctypes.QueryParams{
+		To:       "0xcontract",
+		Data:     "0x18160ddd",
+		NumOrTag: evmctypes.FormatNumber(12345),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}

--- a/debug_namespace.go
+++ b/debug_namespace.go
@@ -292,10 +292,7 @@ func (d *debugNamespace) traceBlockByNumber(
 	if traceCfg != nil {
 		params = append(params, *traceCfg)
 	}
-	if err := d.c.call(ctx, result, DebugTraceBlockByNumber, params...); err != nil {
-		return err
-	}
-	return nil
+	return d.c.call(ctx, result, DebugTraceBlockByNumber, params...)
 }
 
 func (d *debugNamespace) TraceBlockByHashWithContext(
@@ -427,10 +424,7 @@ func (d *debugNamespace) traceBlockByHash(
 	if traceCfg != nil {
 		params = append(params, *traceCfg)
 	}
-	if err := d.c.call(ctx, result, DebugTraceBlockByHash, params...); err != nil {
-		return err
-	}
-	return nil
+	return d.c.call(ctx, result, DebugTraceBlockByHash, params...)
 }
 
 func (d *debugNamespace) TraceTransaction(hash string, cfg *TraceConfig) (interface{}, error) {
@@ -568,8 +562,5 @@ func (d *debugNamespace) traceTransaction(
 	if traceCfg != nil {
 		params = append(params, *traceCfg)
 	}
-	if err := d.c.call(ctx, result, DebugTraceTransaction, params...); err != nil {
-		return err
-	}
-	return nil
+	return d.c.call(ctx, result, DebugTraceTransaction, params...)
 }

--- a/debug_namespace_mock_test.go
+++ b/debug_namespace_mock_test.go
@@ -1,0 +1,154 @@
+package evmc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// callTracerResultJSON은 callTracer 결과 mock 데이터.
+// txHash는 결과 객체를 구분하는 트랜잭션 해시다.
+func callTracerResultJSON(txHash string) map[string]interface{} {
+	return map[string]interface{}{
+		"txHash": txHash,
+		"result": map[string]interface{}{
+			"from": "0xfrom",
+			// 0x5208 = 21000 (standard ETH transfer gas)
+			"gas":     "0x5208",
+			"gasUsed": "0x5208",
+			"to":      "0xto",
+			"input":   "0x",
+			"output":  "0xresult",
+			// 0xde0b6b3a7640000 = 1000000000000000000 (1 ETH in wei)
+			"value": "0xde0b6b3a7640000",
+			"type":  "CALL",
+		},
+	}
+}
+
+// traceResultJSON은 structLogger(기본 tracer) 결과 mock 데이터.
+// txHash는 결과 객체를 구분하는 트랜잭션 해시다.
+func traceResultJSON(txHash string) map[string]interface{} {
+	return map[string]interface{}{
+		"txHash": txHash,
+		"result": map[string]interface{}{
+			// 21000: standard ETH transfer gas cost
+			"gas":         21000,
+			"failed":      false,
+			"returnValue": "",
+			"structLogs":  []interface{}{},
+		},
+	}
+}
+
+func Test_debugNamespace_mock_TraceBlockByNumber(t *testing.T) {
+	client := testWithMock(t, "debug_traceBlockByNumber", func(params json.RawMessage) interface{} {
+		return []map[string]interface{}{
+			traceResultJSON("0xtx1"),
+			traceResultJSON("0xtx2"),
+		}
+	})
+	results, err := client.Debug().TraceBlockByNumber(100, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "0xtx1", results[0].TxHash)
+	assert.Equal(t, "0xtx2", results[1].TxHash)
+}
+
+func Test_debugNamespace_mock_TraceBlockByNumber_callTracer(t *testing.T) {
+	client := testWithMock(t, "debug_traceBlockByNumber", func(params json.RawMessage) interface{} {
+		return []map[string]interface{}{
+			callTracerResultJSON("0xtx1"),
+			callTracerResultJSON("0xtx2"),
+		}
+	})
+	results, err := client.Debug().TraceBlockByNumber_callTracer(100, 0, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+	assert.Equal(t, "0xtx1", results[0].TxHash)
+	require.NotNil(t, results[0].Result)
+	assert.Equal(t, "CALL", results[0].Result.Type)
+	assert.Equal(t, "0xfrom", results[0].Result.From)
+}
+
+func Test_debugNamespace_mock_TraceBlockByHash(t *testing.T) {
+	client := testWithMock(t, "debug_traceBlockByHash", func(params json.RawMessage) interface{} {
+		// TraceBlockByHash returns a single TraceResult (not an array)
+		return traceResultJSON("0xtx1")
+	})
+	result, err := client.Debug().TraceBlockByHash("0xblockhash", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func Test_debugNamespace_mock_TraceBlockByHash_callTracer(t *testing.T) {
+	client := testWithMock(t, "debug_traceBlockByHash", func(params json.RawMessage) interface{} {
+		return []map[string]interface{}{
+			callTracerResultJSON("0xtx1"),
+		}
+	})
+	results, err := client.Debug().TraceBlockByHash_callTracer("0xblockhash", 0, nil, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "0xtx1", results[0].TxHash)
+}
+
+func Test_debugNamespace_mock_TraceTransaction(t *testing.T) {
+	client := testWithMock(t, "debug_traceTransaction", func(params json.RawMessage) interface{} {
+		return map[string]interface{}{
+			// 21000: standard ETH transfer gas cost
+			"gas":         21000,
+			"failed":      false,
+			"returnValue": "",
+			"structLogs":  []interface{}{},
+		}
+	})
+	result, err := client.Debug().TraceTransaction("0xtxhash", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}
+
+func Test_debugNamespace_mock_TraceTransaction_callTracer(t *testing.T) {
+	client := testWithMock(t, "debug_traceTransaction", func(params json.RawMessage) interface{} {
+		return map[string]interface{}{
+			"from": "0xfrom",
+			// 0x5208 = 21000 (standard ETH transfer gas)
+			"gas":     "0x5208",
+			"gasUsed": "0x5208",
+			"to":      "0xto",
+			"input":   "0x",
+			"output":  "0xresult",
+			// 0xde0b6b3a7640000 = 1000000000000000000 (1 ETH in wei)
+			"value": "0xde0b6b3a7640000",
+			"type":  "CALL",
+		}
+	})
+	callFrame, err := client.Debug().TraceTransaction_callTracer("0xtxhash", 0, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, callFrame)
+	assert.Equal(t, "0xfrom", callFrame.From)
+	assert.Equal(t, "CALL", callFrame.Type)
+}
+
+func Test_debugNamespace_mock_TraceTransaction_prestateTracer(t *testing.T) {
+	client := testWithMock(t, "debug_traceTransaction", func(params json.RawMessage) interface{} {
+		return map[string]interface{}{
+			"0xfrom": map[string]interface{}{
+				// 0xde0b6b3a7640000 = 1000000000000000000 (1 ETH in wei)
+				"balance": "0xde0b6b3a7640000",
+				// 0x5 = 5
+				"nonce": "0x5",
+			},
+			"0xto": map[string]interface{}{
+				"balance": "0x0",
+				"nonce":   "0x0",
+				"code":    "0x60806040",
+			},
+		}
+	})
+	result, err := client.Debug().TraceTransaction_prestateTracer("0xtxhash", 0, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}

--- a/eth_namespace.go
+++ b/eth_namespace.go
@@ -414,11 +414,7 @@ func (e *ethNamespace) getBlockByNumber(
 	if number == evmctypes.Pending {
 		return ErrPendingBlockNotSupported
 	}
-	params := []interface{}{number.String(), incTx}
-	if err := e.c.call(ctx, result, EthGetBlockByNumber, params...); err != nil {
-		return err
-	}
-	return nil
+	return e.c.call(ctx, result, EthGetBlockByNumber, number.String(), incTx)
 }
 
 func (e *ethNamespace) GetBlockByHash(hash string) (*evmctypes.Block, error) {
@@ -460,11 +456,7 @@ func (e *ethNamespace) GetBlockIncTxByHashWithContext(ctx context.Context, hash 
 }
 
 func (e *ethNamespace) getBlockByHash(ctx context.Context, result interface{}, hash string, incTx bool) error {
-	params := []interface{}{hash, incTx}
-	if err := e.c.call(ctx, result, EthGetBlockByHash, params...); err != nil {
-		return err
-	}
-	return nil
+	return e.c.call(ctx, result, EthGetBlockByHash, hash, incTx)
 }
 
 func (e *ethNamespace) getUncleBlocks(ctx context.Context, blockNumber uint64, uncles []string) ([]*evmctypes.Block, error) {

--- a/eth_namespace_mock_test.go
+++ b/eth_namespace_mock_test.go
@@ -1,0 +1,483 @@
+package evmc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bbaktaeho/evmc/evmctypes"
+	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// blockJSON은 테스트용 블록 JSON (헥스 인코딩 필드 포함).
+func blockJSON(number string, hash string, withTxHashes bool) map[string]interface{} {
+	b := map[string]interface{}{
+		"number":           number,
+		"hash":             hash,
+		"parentHash":       "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"nonce":            "0x0000000000000000",
+		"mixHash":          "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"sha3Uncles":       "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+		"logsBloom":        "0x00000000000000000000000000000000",
+		"stateRoot":        "0xabcd",
+		"miner":            "0x1234567890123456789012345678901234567890",
+		"difficulty":       "0x0",
+		"extraData":        "0x",
+		"gasLimit":         "0x1c9c380",
+		"gasUsed":          "0x5208",
+		"timestamp":        "0x64",
+		"transactionsRoot": "0xabc",
+		"receiptsRoot":     "0xdef",
+		"totalDifficulty":  "0x0",
+		"size":             "0x200",
+		"uncles":           []string{},
+		"baseFeePerGas":    "0x3b9aca00",
+	}
+	if withTxHashes {
+		b["transactions"] = []string{"0xtx1", "0xtx2"}
+	} else {
+		b["transactions"] = []map[string]interface{}{
+			{
+				"blockHash":        hash,
+				"blockNumber":      number,
+				"from":             "0xfrom",
+				"gas":              "0x5208",
+				"gasPrice":         "0x3b9aca00",
+				"hash":             "0xtx1",
+				"input":            "0x",
+				"nonce":            "0x0",
+				"to":               "0xto",
+				"transactionIndex": "0x0",
+				"value":            "0xde0b6b3a7640000",
+				"type":             "0x2",
+				"v":                "0x1",
+				"r":                "0x1",
+				"s":                "0x1",
+			},
+		}
+	}
+	return b
+}
+
+func receiptJSON(txHash string, blockNumber string, blockHash string) map[string]interface{} {
+	return map[string]interface{}{
+		"blockHash":         blockHash,
+		"blockNumber":       blockNumber,
+		"transactionHash":   txHash,
+		"transactionIndex":  "0x0",
+		"from":              "0xfrom",
+		"to":                "0xto",
+		"gasUsed":           "0x5208",
+		"cumulativeGasUsed": "0x5208",
+		"logs":              []interface{}{},
+		"type":              "0x2",
+		"effectiveGasPrice": "0x3b9aca00",
+		"status":            "0x1",
+		"logsBloom":         "0x00000000",
+	}
+}
+
+// testWithMock은 단일 메서드 핸들러를 등록하고 Evmc 클라이언트를 반환하는 헬퍼.
+// 하나의 RPC 메서드만 모킹하는 간단한 테스트 케이스에 사용한다.
+func testWithMock(t *testing.T, method string, handler func(params json.RawMessage) interface{}) *Evmc {
+	t.Helper()
+	mock := newMockRPCServer(t)
+	mock.on(method, handler)
+	return testEvmc(mock.url())
+}
+
+func Test_ethNamespace_mock_BlockNumber(t *testing.T) {
+	client := testWithMock(t, "eth_blockNumber", func(params json.RawMessage) interface{} {
+		return "0x64"
+	})
+	n, err := client.Eth().BlockNumber()
+	require.NoError(t, err)
+	// 0x64 = 100
+	assert.Equal(t, uint64(100), n)
+}
+
+func Test_ethNamespace_mock_ChainID(t *testing.T) {
+	client := testWithMock(t, "eth_chainId", func(params json.RawMessage) interface{} {
+		return "0x1"
+	})
+	chainID, err := client.Eth().ChainID()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), chainID)
+}
+
+func Test_ethNamespace_mock_GetBlockByNumber(t *testing.T) {
+	client := testWithMock(t, "eth_getBlockByNumber", func(params json.RawMessage) interface{} {
+		return blockJSON("0x64", "0xblockhash", true)
+	})
+	block, err := client.Eth().GetBlockByNumber(100)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), block.Number)
+	assert.Equal(t, "0xblockhash", block.Hash)
+	assert.Len(t, block.Transactions, 2)
+	assert.Equal(t, "0x3b9aca00", *block.BaseFeePerGas)
+}
+
+func Test_ethNamespace_mock_GetBlockByNumber_tag(t *testing.T) {
+	mock := newMockRPCServer(t)
+	mock.on("eth_getBlockByNumber", func(params json.RawMessage) interface{} {
+		var args []interface{}
+		json.Unmarshal(params, &args)
+		tag := args[0].(string)
+		if tag == "latest" {
+			return blockJSON("0x100", "0xlatesthash", true)
+		}
+		return nil
+	})
+
+	client := testEvmc(mock.url())
+	block, err := client.Eth().GetBlockByTag(evmctypes.Latest)
+	require.NoError(t, err)
+	// 0x100 = 256
+	assert.Equal(t, uint64(256), block.Number)
+	assert.Equal(t, "0xlatesthash", block.Hash)
+}
+
+func Test_ethNamespace_mock_GetBlockIncTxByNumber(t *testing.T) {
+	client := testWithMock(t, "eth_getBlockByNumber", func(params json.RawMessage) interface{} {
+		return blockJSON("0x1", "0xhash1", false)
+	})
+	blockIncTx, err := client.Eth().GetBlockIncTxByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), blockIncTx.Number)
+	require.Len(t, blockIncTx.Transactions, 1)
+	assert.Equal(t, "0xtx1", blockIncTx.Transactions[0].Hash)
+	// 0xde0b6b3a7640000 = 1000000000000000000 (1 ETH in wei)
+	assert.True(t, decimal.RequireFromString("1000000000000000000").Equal(blockIncTx.Transactions[0].Value))
+}
+
+func Test_ethNamespace_mock_GetBlockByHash(t *testing.T) {
+	client := testWithMock(t, "eth_getBlockByHash", func(params json.RawMessage) interface{} {
+		return blockJSON("0xa", "0xtesthash", true)
+	})
+	block, err := client.Eth().GetBlockByHash("0xtesthash")
+	require.NoError(t, err)
+	// 0xa = 10
+	assert.Equal(t, uint64(10), block.Number)
+	assert.Equal(t, "0xtesthash", block.Hash)
+}
+
+func Test_ethNamespace_mock_GetTransactionByHash(t *testing.T) {
+	client := testWithMock(t, "eth_getTransactionByHash", func(params json.RawMessage) interface{} {
+		return map[string]interface{}{
+			"blockHash":        "0xblockhash",
+			"blockNumber":      "0x5",
+			"from":             "0xfrom",
+			"gas":              "0x5208",
+			"gasPrice":         "0x3b9aca00",
+			"hash":             "0xtxhash",
+			"input":            "0x",
+			"nonce":            "0x1",
+			"to":               "0xto",
+			"transactionIndex": "0x0",
+			"value":            "0xde0b6b3a7640000",
+			"type":             "0x0",
+			"v":                "0x25",
+			"r":                "0xabc",
+			"s":                "0xdef",
+		}
+	})
+	tx, err := client.Eth().GetTransactionByHash("0xtxhash")
+	require.NoError(t, err)
+	assert.Equal(t, "0xtxhash", tx.Hash)
+	assert.Equal(t, "0xfrom", tx.From)
+	assert.Equal(t, "0xto", tx.To)
+	assert.Equal(t, uint64(5), tx.BlockNumber)
+	// 0xde0b6b3a7640000 = 1000000000000000000 (1 ETH in wei)
+	assert.True(t, decimal.RequireFromString("1000000000000000000").Equal(tx.Value))
+}
+
+func Test_ethNamespace_mock_GetTransactionReceipt(t *testing.T) {
+	client := testWithMock(t, "eth_getTransactionReceipt", func(params json.RawMessage) interface{} {
+		return receiptJSON("0xtxhash", "0x1", "0xblockhash")
+	})
+	receipt, err := client.Eth().GetTransactionReceipt("0xtxhash")
+	require.NoError(t, err)
+	assert.Equal(t, "0xtxhash", receipt.TransactionHash)
+	assert.Equal(t, uint64(1), receipt.BlockNumber)
+	assert.Equal(t, "0x1", *receipt.Status)
+}
+
+func Test_ethNamespace_mock_GetBalance(t *testing.T) {
+	client := testWithMock(t, "eth_getBalance", func(params json.RawMessage) interface{} {
+		// 0xde0b6b3a7640000 = 1000000000000000000 (1 ETH in wei)
+		return "0xde0b6b3a7640000"
+	})
+	balance, err := client.Eth().GetBalance("0xaddr", evmctypes.Latest)
+	require.NoError(t, err)
+	assert.Equal(t, decimal.RequireFromString("1000000000000000000"), balance)
+}
+
+func Test_ethNamespace_mock_GetBalance_Zero(t *testing.T) {
+	client := testWithMock(t, "eth_getBalance", func(params json.RawMessage) interface{} {
+		return "0x0"
+	})
+	balance, err := client.Eth().GetBalance("0xaddr", evmctypes.Latest)
+	require.NoError(t, err)
+	assert.True(t, balance.IsZero())
+}
+
+func Test_ethNamespace_mock_GasPrice(t *testing.T) {
+	client := testWithMock(t, "eth_gasPrice", func(params json.RawMessage) interface{} {
+		// 0x3b9aca00 = 1000000000 (1 Gwei)
+		return "0x3b9aca00"
+	})
+	gasPrice, err := client.Eth().GasPrice()
+	require.NoError(t, err)
+	assert.Equal(t, decimal.RequireFromString("1000000000"), gasPrice)
+}
+
+func Test_ethNamespace_mock_MaxPriorityFeePerGas(t *testing.T) {
+	client := testWithMock(t, "eth_maxPriorityFeePerGas", func(params json.RawMessage) interface{} {
+		// 0x77359400 = 2000000000 (2 Gwei)
+		return "0x77359400"
+	})
+	fee, err := client.Eth().MaxPriorityFeePerGas()
+	require.NoError(t, err)
+	assert.Equal(t, decimal.RequireFromString("2000000000"), fee)
+}
+
+func Test_ethNamespace_mock_GetTransactionCount(t *testing.T) {
+	client := testWithMock(t, "eth_getTransactionCount", func(params json.RawMessage) interface{} {
+		// 0x2a = 42
+		return "0x2a"
+	})
+	nonce, err := client.Eth().GetTransactionCount("0xaddr", evmctypes.Latest)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(42), nonce)
+}
+
+func Test_ethNamespace_mock_GetCode(t *testing.T) {
+	client := testWithMock(t, "eth_getCode", func(params json.RawMessage) interface{} {
+		return "0x60806040"
+	})
+	code, err := client.Eth().GetCode("0xcontract", evmctypes.Latest)
+	require.NoError(t, err)
+	assert.Equal(t, "0x60806040", code)
+}
+
+func Test_ethNamespace_mock_GetStorageAt(t *testing.T) {
+	client := testWithMock(t, "eth_getStorageAt", func(params json.RawMessage) interface{} {
+		return "0x0000000000000000000000000000000000000000000000000000000000000001"
+	})
+	storage, err := client.Eth().GetStorageAt("0xaddr", "0x0", evmctypes.Latest)
+	require.NoError(t, err)
+	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000001", storage)
+}
+
+func Test_ethNamespace_mock_GetLogs(t *testing.T) {
+	client := testWithMock(t, "eth_getLogs", func(params json.RawMessage) interface{} {
+		return []map[string]interface{}{
+			{
+				"address":          "0xcontract",
+				"topics":           []string{"0xtopic1"},
+				"data":             "0xdata",
+				"blockNumber":      "0x1",
+				"transactionHash":  "0xtxhash",
+				"transactionIndex": "0x0",
+				"blockHash":        "0xblockhash",
+				"logIndex":         "0x0",
+				"removed":          false,
+				// 0x64 = 100 (unix timestamp)
+				"blockTimestamp": "0x64",
+			},
+		}
+	})
+	fromBlock := uint64(1)
+	toBlock := uint64(10)
+	addr := "0xcontract"
+	logs, err := client.Eth().GetLogs(&evmctypes.LogFilter{
+		FromBlock: &fromBlock,
+		ToBlock:   &toBlock,
+		Address:   &addr,
+	})
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	assert.Equal(t, "0xcontract", logs[0].Address)
+	assert.Equal(t, []string{"0xtopic1"}, logs[0].Topics)
+	assert.Equal(t, uint64(1), logs[0].BlockNumber)
+	assert.Equal(t, uint64(100), logs[0].BlockTimestamp)
+}
+
+func Test_ethNamespace_mock_GetBlockReceipts(t *testing.T) {
+	client := testWithMock(t, "eth_getBlockReceipts", func(params json.RawMessage) interface{} {
+		return []map[string]interface{}{
+			receiptJSON("0xtx1", "0x1", "0xblockhash"),
+			receiptJSON("0xtx2", "0x1", "0xblockhash"),
+		}
+	})
+	receipts, err := client.Eth().GetBlockReceipts(1)
+	require.NoError(t, err)
+	require.Len(t, receipts, 2)
+	assert.Equal(t, "0xtx1", receipts[0].TransactionHash)
+	assert.Equal(t, "0xtx2", receipts[1].TransactionHash)
+}
+
+func Test_ethNamespace_mock_BlockTransactionCountByNumber(t *testing.T) {
+	client := testWithMock(t, "eth_getBlockTransactionCountByNumber", func(params json.RawMessage) interface{} {
+		// 0xa = 10
+		return "0xa"
+	})
+	count, err := client.Eth().BlockTransactionCountByNumber(1)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(10), count)
+}
+
+func Test_ethNamespace_mock_BlockTransactionCountByHash(t *testing.T) {
+	client := testWithMock(t, "eth_getBlockTransactionCountByHash", func(params json.RawMessage) interface{} {
+		return "0x5"
+	})
+	count, err := client.Eth().BlockTransactionCountByHash("0xhash")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(5), count)
+}
+
+func Test_ethNamespace_mock_FeeHistory(t *testing.T) {
+	client := testWithMock(t, "eth_feeHistory", func(params json.RawMessage) interface{} {
+		return map[string]interface{}{
+			// 0x64 = 100
+			"oldestBlock":   "0x64",
+			"baseFeePerGas": []string{"0x3b9aca00", "0x77359400"},
+			"gasUsedRatio":  []float64{0.5, 0.8},
+		}
+	})
+	feeHistory, err := client.Eth().FeeHistory(2, evmctypes.Latest, nil)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(100), feeHistory.OldestBlock)
+	assert.Len(t, feeHistory.BaseFeePerGas, 2)
+	assert.Len(t, feeHistory.GasUsedRatio, 2)
+}
+
+func Test_ethNamespace_mock_EstimateGas(t *testing.T) {
+	client := testWithMock(t, "eth_estimateGas", func(params json.RawMessage) interface{} {
+		// 0x5208 = 21000 (standard ETH transfer gas)
+		return "0x5208"
+	})
+	gas, err := client.Eth().EstimateGas(&Tx{
+		From:  ZeroAddress,
+		To:    ZeroAddress,
+		Data:  "0x",
+		Value: decimal.Zero,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(21000), gas)
+}
+
+func Test_ethNamespace_mock_Call(t *testing.T) {
+	client := testWithMock(t, "eth_call", func(params json.RawMessage) interface{} {
+		return "0x0000000000000000000000000000000000000000000000000de0b6b3a7640000"
+	})
+	result, err := client.Eth().Call(&Tx{
+		From: ZeroAddress,
+		To:   "0xcontract",
+		Data: "0x18160ddd",
+	}, evmctypes.Latest)
+	require.NoError(t, err)
+	assert.NotEmpty(t, result)
+}
+
+func Test_ethNamespace_mock_GetBlockRange(t *testing.T) {
+	mock := newMockRPCServer(t)
+	callCount := 0
+	mock.on("eth_getBlockByNumber", func(params json.RawMessage) interface{} {
+		callCount++
+		var args []interface{}
+		json.Unmarshal(params, &args)
+		hexNum := args[0].(string)
+		return blockJSON(hexNum, "0xhash"+hexNum, true)
+	})
+
+	client := testEvmc(mock.url())
+	blocks, err := client.Eth().GetBlockRange(1, 3)
+	require.NoError(t, err)
+	assert.Len(t, blocks, 3)
+	assert.Equal(t, uint64(1), blocks[0].Number)
+	assert.Equal(t, uint64(2), blocks[1].Number)
+	assert.Equal(t, uint64(3), blocks[2].Number)
+}
+
+func Test_ethNamespace_mock_GetBlockRange_InvalidRange(t *testing.T) {
+	mock := newMockRPCServer(t)
+	client := testEvmc(mock.url())
+	_, err := client.Eth().GetBlockRange(10, 5)
+	require.ErrorIs(t, err, ErrInvalidRange)
+}
+
+func Test_ethNamespace_mock_Syncing_false(t *testing.T) {
+	client := testWithMock(t, "eth_syncing", func(params json.RawMessage) interface{} {
+		return false
+	})
+	syncing, _, err := client.Eth().Syncing()
+	require.NoError(t, err)
+	assert.False(t, syncing)
+}
+
+func Test_ethNamespace_mock_GetLogsByBlockNumber(t *testing.T) {
+	client := testWithMock(t, "eth_getLogs", func(params json.RawMessage) interface{} {
+		return []map[string]interface{}{
+			{
+				"address": "0xcontract",
+				"topics":  []string{},
+				"data":    "0x",
+				// 0xa = 10
+				"blockNumber":      "0xa",
+				"transactionHash":  "0xtxhash",
+				"transactionIndex": "0x0",
+				"blockHash":        "0xblockhash",
+				"logIndex":         "0x0",
+				"removed":          false,
+			},
+		}
+	})
+	logs, err := client.Eth().GetLogsByBlockNumber(10)
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	assert.Equal(t, uint64(10), logs[0].BlockNumber)
+}
+
+func Test_ethNamespace_mock_GetLogsByBlockHash(t *testing.T) {
+	client := testWithMock(t, "eth_getLogs", func(params json.RawMessage) interface{} {
+		return []map[string]interface{}{
+			{
+				"address": "0xcontract",
+				"topics":  []string{},
+				"data":    "0x",
+				// 0xa = 10
+				"blockNumber":      "0xa",
+				"transactionHash":  "0xtxhash",
+				"transactionIndex": "0x0",
+				"blockHash":        "0xtesthash",
+				"logIndex":         "0x0",
+				"removed":          false,
+			},
+		}
+	})
+	logs, err := client.Eth().GetLogsByBlockHash("0xtesthash")
+	require.NoError(t, err)
+	require.Len(t, logs, 1)
+	assert.Equal(t, "0xtesthash", logs[0].BlockHash)
+}
+
+func Test_ethNamespace_mock_BlobBaseFee(t *testing.T) {
+	client := testWithMock(t, "eth_blobBaseFee", func(params json.RawMessage) interface{} {
+		// 0x3b9aca00 = 1000000000 (1 Gwei)
+		return "0x3b9aca00"
+	})
+	fee, err := client.Eth().BlobBaseFee()
+	require.NoError(t, err)
+	assert.Equal(t, decimal.RequireFromString("1000000000"), fee)
+}
+
+func Test_ethNamespace_mock_SendRawTransaction(t *testing.T) {
+	client := testWithMock(t, "eth_sendRawTransaction", func(params json.RawMessage) interface{} {
+		return "0xsentTxHash"
+	})
+	txHash, err := client.Eth().SendRawTransaction("0xrawTx")
+	require.NoError(t, err)
+	assert.Equal(t, "0xsentTxHash", txHash)
+}

--- a/evmctypes/block_and_tag.go
+++ b/evmctypes/block_and_tag.go
@@ -1,10 +1,6 @@
 package evmctypes
 
-import (
-	"reflect"
-
-	"github.com/ethereum/go-ethereum/common/hexutil"
-)
+import "github.com/ethereum/go-ethereum/common/hexutil"
 
 type BlockAndTag string
 
@@ -24,17 +20,20 @@ func (b BlockAndTag) String() string {
 	return string(b)
 }
 
+// FormatNumber returns a BlockAndTag representing the given block number in hex.
 func FormatNumber(number uint64) BlockAndTag {
 	return BlockAndTag(hexutil.EncodeUint64(number))
 }
 
-func ParseBlockAndTag(blockAndTag interface{}) string {
-	if reflect.TypeOf(blockAndTag).Kind() != reflect.String {
+// ParseBlockAndTag returns the string form of a block tag or number.
+// If v is a BlockAndTag or string, it is returned as-is; otherwise "latest" is returned.
+func ParseBlockAndTag(v interface{}) string {
+	switch val := v.(type) {
+	case BlockAndTag:
+		return val.String()
+	case string:
+		return val
+	default:
 		return Latest.String()
 	}
-	tag, ok := blockAndTag.(BlockAndTag)
-	if !ok {
-		return blockAndTag.(string)
-	}
-	return tag.String()
 }

--- a/evmctypes/evmctypes_test.go
+++ b/evmctypes/evmctypes_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Block(t *testing.T) {
@@ -204,4 +205,495 @@ func Test_Receipt(t *testing.T) {
 	assert.Equal(t, "0xf", *receipt.Root)
 	assert.Equal(t, "0x10", *receipt.Status)
 	assert.Equal(t, "0x11", receipt.LogsBloom)
+}
+
+// mustMarshalUnmarshal은 raw 맵을 JSON으로 직렬화한 후 target에 역직렬화한다.
+// 직렬화나 역직렬화 중 에러가 발생하면 즉시 테스트를 실패시킨다.
+func mustMarshalUnmarshal[T any](t *testing.T, raw map[string]interface{}, target *T) {
+	t.Helper()
+	rawBytes, err := json.Marshal(raw)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(rawBytes, target))
+}
+
+func Test_Log(t *testing.T) {
+	raw := map[string]interface{}{
+		"address":          "0xabc",
+		"topics":           []string{"0x1", "0x2"},
+		"data":             "0xdeadbeef",
+		"blockNumber":      "0xa",
+		"transactionHash":  "0xhash",
+		"transactionIndex": "0x3",
+		"blockHash":        "0xblockhash",
+		"logIndex":         "0x5",
+		"removed":          false,
+		"blockTimestamp":   "0x64",
+	}
+
+	log := new(Log)
+	mustMarshalUnmarshal(t, raw, log)
+
+	assert.Equal(t, "0xabc", log.Address)
+	assert.Equal(t, []string{"0x1", "0x2"}, log.Topics)
+	assert.Equal(t, "0xdeadbeef", log.Data)
+	assert.Equal(t, uint64(10), log.BlockNumber)
+	assert.Equal(t, "0xhash", log.TransactionHash)
+	assert.Equal(t, uint64(3), log.TransactionIndex)
+	assert.Equal(t, "0xblockhash", log.BlockHash)
+	assert.Equal(t, uint64(5), log.LogIndex)
+	assert.False(t, log.Removed)
+	assert.Equal(t, uint64(100), log.BlockTimestamp)
+}
+
+func Test_Log_Removed(t *testing.T) {
+	raw := map[string]interface{}{
+		"address":         "0xabc",
+		"topics":          []string{},
+		"data":            "0x",
+		"blockNumber":     "0x1",
+		"transactionHash": "0xhash",
+		"blockHash":       "0xblockhash",
+		"removed":         true,
+	}
+
+	log := new(Log)
+	mustMarshalUnmarshal(t, raw, log)
+
+	assert.True(t, log.Removed)
+}
+
+func Test_FeeHistory(t *testing.T) {
+	raw := map[string]interface{}{
+		"oldestBlock":   "0x64",
+		"baseFeePerGas": []string{"0x1", "0x2", "0x3"},
+		"gasUsedRatio":  []float64{0.1, 0.5, 0.9},
+		"reward":        [][]string{{"0xa"}, {"0xb"}},
+	}
+
+	feeHistory := new(FeeHistory)
+	mustMarshalUnmarshal(t, raw, feeHistory)
+
+	assert.Equal(t, uint64(100), feeHistory.OldestBlock)
+	assert.Equal(t, []string{"0x1", "0x2", "0x3"}, feeHistory.BaseFeePerGas)
+	assert.Equal(t, []float64{0.1, 0.5, 0.9}, feeHistory.GasUsedRatio)
+	assert.Equal(t, [][]string{{"0xa"}, {"0xb"}}, feeHistory.Reward)
+}
+
+func Test_FeeHistory_WithBlobGas(t *testing.T) {
+	raw := map[string]interface{}{
+		"oldestBlock":       "0x1",
+		"baseFeePerBlobGas": []string{"0x100", "0x200"},
+		"blobGasUsedRatio":  []float64{0.3, 0.7},
+	}
+
+	feeHistory := new(FeeHistory)
+	mustMarshalUnmarshal(t, raw, feeHistory)
+
+	assert.Equal(t, uint64(1), feeHistory.OldestBlock)
+	assert.Equal(t, []string{"0x100", "0x200"}, feeHistory.BaseFeePerBlobGas)
+	assert.Equal(t, []float64{0.3, 0.7}, feeHistory.BlobGasUsedRatio)
+}
+
+func Test_Syncing(t *testing.T) {
+	raw := map[string]interface{}{
+		"startingBlock":          "0x1",
+		"currentBlock":           "0xa",
+		"highestBlock":           "0x64",
+		"syncedAccounts":         "0x10",
+		"syncedAccountBytes":     "0x20",
+		"syncedBytecodes":        "0x30",
+		"syncedBytecodeBytes":    "0x40",
+		"syncedStorage":          "0x50",
+		"syncedStorageBytes":     "0x60",
+		"healedTrienodes":        "0x70",
+		"healedTrienodeBytes":    "0x80",
+		"healedBytecodes":        "0x90",
+		"healedBytecodeBytes":    "0xa0",
+		"healingTrienodes":       "0xb0",
+		"healingBytecode":        "0xc0",
+		"txIndexFinishedBlocks":  "0xd0",
+		"txIndexRemainingBlocks": "0xe0",
+	}
+
+	syncing := new(Syncing)
+	mustMarshalUnmarshal(t, raw, syncing)
+
+	assert.Equal(t, uint64(1), syncing.StartingBlock)
+	assert.Equal(t, uint64(10), syncing.CurrentBlock)
+	assert.Equal(t, uint64(100), syncing.HighestBlock)
+	assert.Equal(t, uint64(16), syncing.SyncedAccounts)
+	assert.Equal(t, uint64(32), syncing.SyncedAccountBytes)
+	assert.Equal(t, uint64(48), syncing.SyncedBytecodes)
+	assert.Equal(t, uint64(64), syncing.SyncedBytecodeBytes)
+	assert.Equal(t, uint64(80), syncing.SyncedStorage)
+	assert.Equal(t, uint64(96), syncing.SyncedStorageBytes)
+	assert.Equal(t, uint64(112), syncing.HealedTrienodes)
+	assert.Equal(t, uint64(128), syncing.HealedTrienodeBytes)
+	assert.Equal(t, uint64(144), syncing.HealedBytecodes)
+	assert.Equal(t, uint64(160), syncing.HealedBytecodeBytes)
+	assert.Equal(t, uint64(176), syncing.HealingTrienodes)
+	assert.Equal(t, uint64(192), syncing.HealingBytecode)
+	assert.Equal(t, uint64(208), syncing.TxIndexFinishedBlocks)
+	assert.Equal(t, uint64(224), syncing.TxIndexRemainingBlocks)
+}
+
+func Test_BlockIncTx(t *testing.T) {
+	raw := map[string]interface{}{
+		"number":           "0x1",
+		"hash":             "0xhash",
+		"parentHash":       "0xparent",
+		"nonce":            "0x0",
+		"mixHash":          "0x0",
+		"sha3Uncles":       "0x0",
+		"logsBloom":        "0x0",
+		"stateRoot":        "0x0",
+		"miner":            "0xminer",
+		"difficulty":       "0x0",
+		"extraData":        "0x",
+		"gasLimit":         "0x1000",
+		"gasUsed":          "0x500",
+		"timestamp":        "0x1",
+		"transactionsRoot": "0x0",
+		"receiptsRoot":     "0x0",
+		"transactions": []map[string]interface{}{
+			{
+				"blockHash":        "0xhash",
+				"blockNumber":      "0x1",
+				"from":             "0xfrom",
+				"gas":              "0x5208",
+				"gasPrice":         "0x1",
+				"hash":             "0xtxhash",
+				"input":            "0x",
+				"nonce":            "0x0",
+				"to":               "0xto",
+				"transactionIndex": "0x0",
+				"value":            "0x0",
+				"type":             "0x0",
+				"v":                "0x1",
+				"r":                "0x1",
+				"s":                "0x1",
+			},
+		},
+	}
+
+	blockIncTx := new(BlockIncTx)
+	mustMarshalUnmarshal(t, raw, blockIncTx)
+
+	assert.Equal(t, uint64(1), blockIncTx.Number)
+	assert.Equal(t, "0xhash", blockIncTx.Hash)
+	require.Len(t, blockIncTx.Transactions, 1)
+	assert.Equal(t, "0xtxhash", blockIncTx.Transactions[0].Hash)
+	assert.Equal(t, uint64(0), blockIncTx.Transactions[0].TransactionIndex)
+}
+
+func Test_Header(t *testing.T) {
+	raw := map[string]interface{}{
+		"number":           "0xa",
+		"hash":             "0xheaderhash",
+		"parentHash":       "0xparent",
+		"nonce":            "0x0",
+		"mixHash":          "0x0",
+		"sha3Uncles":       "0x0",
+		"logsBloom":        "0x0",
+		"stateRoot":        "0x0",
+		"miner":            "0xminer",
+		"difficulty":       "0x0",
+		"extraData":        "0x",
+		"gasLimit":         "0x1000",
+		"gasUsed":          "0x500",
+		"timestamp":        "0x5f5e100",
+		"transactionsRoot": "0x0",
+		"receiptsRoot":     "0x0",
+	}
+
+	header := new(Header)
+	mustMarshalUnmarshal(t, raw, header)
+
+	assert.Equal(t, uint64(10), header.Number)
+	assert.Equal(t, "0xheaderhash", header.Hash)
+	assert.Equal(t, uint64(100000000), header.Timestamp)
+}
+
+func Test_CallFrame(t *testing.T) {
+	raw := map[string]interface{}{
+		"from":    "0xfrom",
+		"gas":     "0x5208",
+		"gasUsed": "0x5208",
+		"to":      "0xto",
+		"input":   "0x",
+		"output":  "0xresult",
+		"value":   "0xde0b6b3a7640000",
+		"type":    "CALL",
+		"calls": []map[string]interface{}{
+			{
+				"from":    "0xfrom2",
+				"gas":     "0x1000",
+				"gasUsed": "0x500",
+				"input":   "0x",
+				"type":    "STATICCALL",
+			},
+		},
+	}
+
+	callFrame := new(CallFrame)
+	mustMarshalUnmarshal(t, raw, callFrame)
+
+	assert.Equal(t, "0xfrom", callFrame.From)
+	assert.Equal(t, "0x5208", callFrame.Gas)
+	assert.Equal(t, "0x5208", callFrame.GasUsed)
+	assert.Equal(t, "CALL", callFrame.Type)
+	require.NotNil(t, callFrame.To)
+	assert.Equal(t, "0xto", *callFrame.To)
+	require.NotNil(t, callFrame.Output)
+	assert.Equal(t, "0xresult", *callFrame.Output)
+	require.NotNil(t, callFrame.Value)
+	assert.Equal(t, decimal.RequireFromString("1000000000000000000"), *callFrame.Value)
+	require.Len(t, callFrame.Calls, 1)
+	assert.Equal(t, "STATICCALL", callFrame.Calls[0].Type)
+}
+
+func Test_CallFrame_WithError(t *testing.T) {
+	raw := map[string]interface{}{
+		"from":         "0xfrom",
+		"gas":          "0x5208",
+		"gasUsed":      "0x5208",
+		"input":        "0x",
+		"type":         "CALL",
+		"error":        "execution reverted",
+		"revertReason": "Ownable: caller is not the owner",
+	}
+
+	callFrame := new(CallFrame)
+	mustMarshalUnmarshal(t, raw, callFrame)
+
+	require.NotNil(t, callFrame.Error)
+	assert.Equal(t, "execution reverted", *callFrame.Error)
+	require.NotNil(t, callFrame.RevertReason)
+	assert.Equal(t, "Ownable: caller is not the owner", *callFrame.RevertReason)
+}
+
+func Test_FlatCallFrame(t *testing.T) {
+	callType := "call"
+	from := "0xfrom"
+	to := "0xto"
+	gas := "0x5208"
+	input := "0x"
+	value := "0xde0b6b3a7640000"
+
+	raw := map[string]interface{}{
+		"action": map[string]interface{}{
+			"callType": callType,
+			"from":     from,
+			"to":       to,
+			"gas":      gas,
+			"input":    input,
+			"value":    value,
+		},
+		"blockHash":           "0xblockhash",
+		"blockNumber":         uint64(100),
+		"subtraces":           uint64(0),
+		"traceAddress":        []uint64{},
+		"transactionHash":     "0xtxhash",
+		"transactionPosition": uint64(0),
+		"type":                "call",
+	}
+
+	flatFrame := new(FlatCallFrame)
+	mustMarshalUnmarshal(t, raw, flatFrame)
+
+	assert.Equal(t, "0xblockhash", flatFrame.BlockHash)
+	assert.Equal(t, uint64(100), flatFrame.BlockNumber)
+	assert.Equal(t, "0xtxhash", flatFrame.TransactionHash)
+	assert.Equal(t, "call", flatFrame.Type)
+	require.NotNil(t, flatFrame.Action.CallType)
+	assert.Equal(t, "call", *flatFrame.Action.CallType)
+	require.NotNil(t, flatFrame.Action.Value)
+	assert.Equal(t, decimal.RequireFromString("1000000000000000000"), *flatFrame.Action.Value)
+}
+
+func Test_BlockAndTag(t *testing.T) {
+	t.Run("constants", func(t *testing.T) {
+		assert.Equal(t, "pending", Pending.String())
+		assert.Equal(t, "earliest", Earliest.String())
+		assert.Equal(t, "latest", Latest.String())
+		assert.Equal(t, "safe", Safe.String())
+		assert.Equal(t, "finalized", Finalized.String())
+	})
+
+	t.Run("FormatNumber", func(t *testing.T) {
+		tag := FormatNumber(100)
+		assert.Equal(t, BlockAndTag("0x64"), tag)
+
+		tag0 := FormatNumber(0)
+		assert.Equal(t, BlockAndTag("0x0"), tag0)
+	})
+
+	t.Run("Uint64", func(t *testing.T) {
+		tag := BlockAndTag("0x64")
+		n, err := tag.Uint64()
+		require.NoError(t, err)
+		assert.Equal(t, uint64(100), n)
+	})
+
+	t.Run("ParseBlockAndTag with BlockAndTag", func(t *testing.T) {
+		result := ParseBlockAndTag(Latest)
+		assert.Equal(t, "latest", result)
+	})
+
+	t.Run("ParseBlockAndTag with string", func(t *testing.T) {
+		result := ParseBlockAndTag("0x64")
+		assert.Equal(t, "0x64", result)
+	})
+
+	t.Run("ParseBlockAndTag with non-string falls back to latest", func(t *testing.T) {
+		result := ParseBlockAndTag(42)
+		assert.Equal(t, "latest", result)
+	})
+}
+
+func Test_Transaction_EIP1559(t *testing.T) {
+	maxFeePerGas := "0x77359400"
+	maxPriorityFeePerGas := "0x3b9aca00"
+	chainID := "0x1"
+	yParity := "0x1"
+
+	raw := map[string]interface{}{
+		"blockHash":            "0x1",
+		"blockNumber":          "0x1",
+		"from":                 "0xfrom",
+		"gas":                  "0x5208",
+		"gasPrice":             "0x0",
+		"hash":                 "0xhash",
+		"input":                "0x",
+		"nonce":                "0x0",
+		"to":                   "0xto",
+		"transactionIndex":     "0x0",
+		"value":                "0x0",
+		"type":                 "0x2",
+		"v":                    "0x0",
+		"r":                    "0x1",
+		"s":                    "0x1",
+		"maxFeePerGas":         maxFeePerGas,
+		"maxPriorityFeePerGas": maxPriorityFeePerGas,
+		"chainId":              chainID,
+		"yParity":              yParity,
+		"accessList":           []interface{}{},
+	}
+
+	tx := new(Transaction)
+	mustMarshalUnmarshal(t, raw, tx)
+
+	assert.Equal(t, "0x2", tx.Type)
+	require.NotNil(t, tx.MaxFeePerGas)
+	assert.Equal(t, maxFeePerGas, *tx.MaxFeePerGas)
+	require.NotNil(t, tx.MaxPriorityFeePerGas)
+	assert.Equal(t, maxPriorityFeePerGas, *tx.MaxPriorityFeePerGas)
+	require.NotNil(t, tx.ChainID)
+	assert.Equal(t, chainID, *tx.ChainID)
+	require.NotNil(t, tx.YParity)
+	assert.Equal(t, yParity, *tx.YParity)
+	assert.NotNil(t, tx.AccessList)
+}
+
+func Test_Receipt_L1Fields(t *testing.T) {
+	raw := map[string]interface{}{
+		"blockHash":         "0x1",
+		"blockNumber":       "0x1",
+		"transactionHash":   "0x2",
+		"transactionIndex":  "0x0",
+		"from":              "0xfrom",
+		"to":                "0xto",
+		"gasUsed":           "0x5208",
+		"cumulativeGasUsed": "0x5208",
+		"logs":              []interface{}{},
+		"type":              "0x7e",
+		"effectiveGasPrice": "0x0",
+		"logsBloom":         "0x0",
+		"l1BlockNumber":     "0x64",
+		"l1GasPrice":        "0xabcd",
+		"l1GasUsed":         "0x1234",
+		"l1Fee":             "0x5678",
+	}
+
+	receipt := new(Receipt)
+	mustMarshalUnmarshal(t, raw, receipt)
+
+	require.NotNil(t, receipt.L1BlockNumber)
+	assert.Equal(t, uint64(100), *receipt.L1BlockNumber)
+	require.NotNil(t, receipt.L1GasPrice)
+	assert.Equal(t, "0xabcd", *receipt.L1GasPrice)
+	require.NotNil(t, receipt.L1GasUsed)
+	assert.Equal(t, "0x1234", *receipt.L1GasUsed)
+	require.NotNil(t, receipt.L1Fee)
+	assert.Equal(t, "0x5678", *receipt.L1Fee)
+}
+
+func Test_Block_MilliTimestamp(t *testing.T) {
+	raw := map[string]interface{}{
+		"number":           "0x1",
+		"hash":             "0xhash",
+		"parentHash":       "0x0",
+		"nonce":            "0x0",
+		"mixHash":          "0x0",
+		"sha3Uncles":       "0x0",
+		"logsBloom":        "0x0",
+		"stateRoot":        "0x0",
+		"miner":            "0xminer",
+		"difficulty":       "0x0",
+		"extraData":        "0x",
+		"gasLimit":         "0x1000",
+		"gasUsed":          "0x0",
+		"timestamp":        "0x64",
+		"transactionsRoot": "0x0",
+		"receiptsRoot":     "0x0",
+		"transactions":     []string{},
+		"milliTimestamp":   "0x17a4f8dadb8",
+	}
+
+	block := new(Block)
+	mustMarshalUnmarshal(t, raw, block)
+
+	require.NotNil(t, block.MilliTimestamp)
+	assert.Equal(t, uint64(1624832323000), *block.MilliTimestamp)
+}
+
+func Test_Block_WithdrawalsAndUncles(t *testing.T) {
+	raw := map[string]interface{}{
+		"number":           "0x1",
+		"hash":             "0xhash",
+		"parentHash":       "0x0",
+		"nonce":            "0x0",
+		"mixHash":          "0x0",
+		"sha3Uncles":       "0x0",
+		"logsBloom":        "0x0",
+		"stateRoot":        "0x0",
+		"miner":            "0xminer",
+		"difficulty":       "0x0",
+		"extraData":        "0x",
+		"gasLimit":         "0x1000",
+		"gasUsed":          "0x0",
+		"timestamp":        "0x1",
+		"transactionsRoot": "0x0",
+		"receiptsRoot":     "0x0",
+		"transactions":     []string{"0xtx1"},
+		"uncles":           []string{"0xuncle1"},
+		"withdrawals": []map[string]interface{}{
+			{
+				"index":          "0x0",
+				"validatorIndex": "0x10",
+				"address":        "0xvalidator",
+				"amount":         "0x3b9aca00",
+			},
+		},
+	}
+
+	block := new(Block)
+	mustMarshalUnmarshal(t, raw, block)
+
+	assert.Equal(t, []string{"0xuncle1"}, block.Uncles)
+	require.Len(t, block.Withdrawals, 1)
+	assert.Equal(t, uint64(0), block.Withdrawals[0].Index)
+	assert.Equal(t, uint64(16), block.Withdrawals[0].ValidatorIndex)
+	assert.Equal(t, "0xvalidator", block.Withdrawals[0].Address)
+	assert.Equal(t, uint64(1000000000), block.Withdrawals[0].Amount)
 }

--- a/evmctypes/prestate_unmarshaling.go
+++ b/evmctypes/prestate_unmarshaling.go
@@ -7,21 +7,21 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// UnmarshalJSON unmarshals PrestateAccount from JSON.
+// UnmarshalJSON implements json.Unmarshaler for PrestateAccount.
+// Balance is decoded from a hex string to decimal.Decimal.
+// Nonce is an integer (not hex) as returned by geth.
 func (pa *PrestateAccount) UnmarshalJSON(input []byte) error {
-	type PrestateAccount0 struct {
+	type wire struct {
 		Balance  *string           `json:"balance,omitempty"`
 		Code     *string           `json:"code,omitempty"`
 		CodeHash *string           `json:"codeHash,omitempty"`
 		Nonce    *uint64           `json:"nonce,omitempty"`
 		Storage  map[string]string `json:"storage,omitempty"`
 	}
-	var dec PrestateAccount0
+	var dec wire
 	if err := json.Unmarshal(input, &dec); err != nil {
 		return err
 	}
-
-	// Decode balance from hex string to decimal
 	if dec.Balance != nil {
 		balanceBig, err := hexutil.DecodeBig(*dec.Balance)
 		if err != nil {
@@ -30,26 +30,17 @@ func (pa *PrestateAccount) UnmarshalJSON(input []byte) error {
 		balance := decimal.NewFromBigInt(balanceBig, 0)
 		pa.Balance = &balance
 	}
-
-	// Copy code
 	if dec.Code != nil {
 		pa.Code = *dec.Code
 	}
-
-	// Copy codeHash
 	if dec.CodeHash != nil {
 		pa.CodeHash = *dec.CodeHash
 	}
-
-	// Decode nonce from hex string to uint64
 	if dec.Nonce != nil {
 		pa.Nonce = *dec.Nonce
 	}
-
-	// Copy storage map
 	if dec.Storage != nil {
 		pa.Storage = dec.Storage
 	}
-
 	return nil
 }

--- a/evmcutils/evmcutils_test.go
+++ b/evmcutils/evmcutils_test.go
@@ -65,9 +65,36 @@ func TestGenerateTxInput(t *testing.T) {
 			want: "0x91ca8b56000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000a3f6849f78076aefadf113f5bed87720274ddc00000000000000000000000000a3f6849f78076aefadf113f5bed87720274ddc0",
 		},
 		{
-			name: "error",
+			name: "no args",
+			args: args{
+				funcSig: "totalSupply()",
+				args:    []evmcsoltypes.SolType{},
+			},
+			want: "0x18160ddd",
+		},
+		{
+			name: "balanceOf",
+			args: args{
+				funcSig: "balanceOf(address)",
+				args: []evmcsoltypes.SolType{
+					evmcsoltypes.Address("0x0a3f6849f78076aefaDf113F5BED87720274dDC0"),
+				},
+			},
+			want: "0x70a082310000000000000000000000000a3f6849f78076aefadf113f5bed87720274ddc0",
+		},
+		{
+			name: "error invalid sig",
 			args: args{
 				funcSig: "invalid",
+				args:    []evmcsoltypes.SolType{},
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "error no parentheses",
+			args: args{
+				funcSig: "transfer address uint256",
 				args:    []evmcsoltypes.SolType{},
 			},
 			want:    "",
@@ -109,6 +136,14 @@ func TestGenerateLogTopic(t *testing.T) {
 				eventSig: "Approval(address,address,uint256)",
 			},
 			want: "0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925",
+		},
+		{
+			name: "error invalid sig",
+			args: args{
+				eventSig: "invalid",
+			},
+			want:    "",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/mock_rpc_test.go
+++ b/mock_rpc_test.go
@@ -1,0 +1,109 @@
+package evmc
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// mockRPCServer는 테스트용 JSON-RPC HTTP 서버.
+type mockRPCServer struct {
+	mu       sync.Mutex
+	handlers map[string]func(params json.RawMessage) interface{}
+	server   *httptest.Server
+}
+
+func newMockRPCServer(t *testing.T) *mockRPCServer {
+	t.Helper()
+	m := &mockRPCServer{
+		handlers: make(map[string]func(params json.RawMessage) interface{}),
+	}
+	m.server = httptest.NewServer(http.HandlerFunc(m.handle))
+	t.Cleanup(m.server.Close)
+	return m
+}
+
+// writeJSON은 응답 헤더를 설정하고 v를 JSON으로 인코딩해 w에 쓴다.
+// 인코딩 중 에러가 발생하면 500 Internal Server Error를 반환한다.
+func writeJSON(w http.ResponseWriter, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, fmt.Sprintf("json encode error: %s", err.Error()), http.StatusInternalServerError)
+	}
+}
+
+func (m *mockRPCServer) handle(w http.ResponseWriter, r *http.Request) {
+	var body json.RawMessage
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+
+	// batch 요청 처리
+	if len(body) > 0 && body[0] == '[' {
+		var reqs []struct {
+			ID     interface{}     `json:"id"`
+			Method string          `json:"method"`
+			Params json.RawMessage `json:"params"`
+		}
+		if err := json.Unmarshal(body, &reqs); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		responses := make([]map[string]interface{}, 0, len(reqs))
+		for _, req := range reqs {
+			responses = append(responses, m.dispatch(req.ID, req.Method, req.Params))
+		}
+		writeJSON(w, responses)
+		return
+	}
+
+	// 단일 요청 처리
+	var req struct {
+		ID     interface{}     `json:"id"`
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	writeJSON(w, m.dispatch(req.ID, req.Method, req.Params))
+}
+
+func (m *mockRPCServer) dispatch(id interface{}, method string, params json.RawMessage) map[string]interface{} {
+	m.mu.Lock()
+	handler, ok := m.handlers[method]
+	m.mu.Unlock()
+
+	if !ok {
+		return map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      id,
+			"error": map[string]interface{}{
+				// JSON-RPC 2.0 error code: method not found
+				"code":    -32601,
+				"message": fmt.Sprintf("method not found: %s", method),
+			},
+		}
+	}
+	result := handler(params)
+	return map[string]interface{}{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"result":  result,
+	}
+}
+
+func (m *mockRPCServer) on(method string, handler func(params json.RawMessage) interface{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.handlers[method] = handler
+}
+
+func (m *mockRPCServer) url() string {
+	return m.server.URL
+}

--- a/web3_namespace_mock_test.go
+++ b/web3_namespace_mock_test.go
@@ -1,0 +1,69 @@
+package evmc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_web3Namespace_mock_ClientVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{
+			name:    "geth",
+			version: "Geth/v1.13.0-stable-64fe2a41/linux-amd64/go1.21.0",
+			want:    "Geth/v1.13.0-stable-64fe2a41/linux-amd64/go1.21.0",
+		},
+		{
+			name:    "erigon",
+			version: "erigon/v2.52.0/linux-amd64/go1.21.0",
+			want:    "erigon/v2.52.0/linux-amd64/go1.21.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := newMockRPCServer(t)
+			mock.on("web3_clientVersion", func(params json.RawMessage) interface{} {
+				return tt.version
+			})
+
+			client := testEvmc(mock.url())
+			version, err := client.Web3().ClientVersion()
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, version)
+		})
+	}
+}
+
+func Test_evmc_NodeClient(t *testing.T) {
+	mock := newMockRPCServer(t)
+	mock.on("web3_clientVersion", func(params json.RawMessage) interface{} {
+		return "Geth/v1.13.0-stable/linux-amd64/go1.21.0"
+	})
+
+	client := testEvmc(mock.url())
+	name, version, err := client.NodeClient()
+	require.NoError(t, err)
+	assert.Equal(t, "Geth", name)
+	assert.Equal(t, "v1.13.0-stable", version)
+}
+
+func Test_evmc_NodeClient_ShortVersion(t *testing.T) {
+	mock := newMockRPCServer(t)
+	mock.on("web3_clientVersion", func(params json.RawMessage) interface{} {
+		return "SimpleClient"
+	})
+
+	client := testEvmc(mock.url())
+	name, version, err := client.NodeClient()
+	require.NoError(t, err)
+	// 슬래시가 없으면 name, version이 빈 문자열
+	assert.Empty(t, name)
+	assert.Empty(t, version)
+}


### PR DESCRIPTION

## Tests
- Add httptest-based mock JSON-RPC server (mock_rpc_test.go) for network-free tests
- Add 40+ mock tests covering eth, debug, web3, contract namespaces
- Add unit tests for evmctypes types: Block, Transaction, Receipt, Log, FeeHistory, Syncing, CallFrame, FlatCallFrame, Header, Withdrawal, PrestateTracer
- Fix prestate_unmarshaling_test.go: nonce is uint64 (integer), not hex string
- Add evmcutils test cases for edge cases

## Effective Go
- Fix httpClient() mutating global http.DefaultTransport (use .Clone() instead)
- Remove unnecessary if-err-return wrapping; return errors directly
- Replace reflect-based type check in ParseBlockAndTag with type switch
- Remove dead commented-out code in evmc.go (batchCall, Trace/Ots getters)
- Remove trivial inline comments in prestate_unmarshaling.go
- Apply gofmt to all test files
- Rename internal wire type from PrestateAccount0 to wire

## Docs
- Add CLAUDE.md with architecture, workflow, and test constraints

## Description

## Fix & Refactoring

## Feat

## Test Reports
